### PR TITLE
Four commits

### DIFF
--- a/bin/instrs2asl.py
+++ b/bin/instrs2asl.py
@@ -5,7 +5,12 @@ Unpack ARM instruction XML files extracting the encoding information
 and ASL code within it.
 '''
 
-import argparse, glob, json, os, re, sys
+import argparse
+import glob
+import json
+import os
+import re
+import sys
 import xml.etree.cElementTree as ET
 from collections import defaultdict
 

--- a/bin/instrs2asl.py
+++ b/bin/instrs2asl.py
@@ -241,7 +241,7 @@ def readNotice(xml):
     notice = ['/'*72, "// Proprietary Notice"]
     for p in xml.iter('para'):
         para = ET.tostring(p, method='text').decode().rstrip()
-        para = para.replace("&#8217;", '"')
+        para = para.replace("&#8217;", "'")
         para = para.replace("&#8220;", '"')
         para = para.replace("&#8221;", '"')
         para = para.replace("&#8482;", '(TM)')


### PR DESCRIPTION
1. New command line options --include and --exclude to early select/reject instructions based on a regex match of their name
2. Minor typo fix
3. Minor style fix (imports one per line)
4. New command line option --sail_ast for emitting Sail AST clauses for each instruction
